### PR TITLE
Re-enable PR commenter

### DIFF
--- a/tf-build/plan-no-lock/action.yml
+++ b/tf-build/plan-no-lock/action.yml
@@ -18,11 +18,11 @@ runs:
         terraform plan -input=false -var-file environments/${{ env.ENVIRONMENT }}/terraform.tfvars -compact-warnings -lock=false
       shell: bash
 
-    #- name: Post Plan
-    #  if: always() && github.ref != 'refs/heads/main' && steps.plan.outcome == 'success' || steps.plan.outcome == 'failure'
-    #  uses: Jimdo/terraform-pr-commenter@v1.6.0
-    #  with:
-    #    commenter_type: plan
-    #    commenter_input: ${{ format('{0}{1}', steps.plan.outputs.stdout, steps.plan.outputs.stderr) }}
-    #    commenter_exitcode: ${{ steps.plan.outputs.exitcode }}
-    #    commenter_comment: "Environment: ${{ env.ENVIRONMENT }}"
+    - name: Post Plan
+     if: always() && github.ref != 'refs/heads/main' && steps.plan.outcome == 'success' || steps.plan.outcome == 'failure'
+     uses: Jimdo/terraform-pr-commenter@v1.6.0
+     with:
+       commenter_type: plan
+       commenter_input: ${{ format('{0}{1}', steps.plan.outputs.stdout, steps.plan.outputs.stderr) }}
+       commenter_exitcode: ${{ steps.plan.outputs.exitcode }}
+       commenter_comment: "Environment: ${{ env.ENVIRONMENT }}"

--- a/tf-build/plan/action.yml
+++ b/tf-build/plan/action.yml
@@ -18,11 +18,11 @@ runs:
         terraform plan -input=false -var-file environments/${{ env.ENVIRONMENT }}/terraform.tfvars -compact-warnings -out=${{ env.ENVIRONMENT }}.plan.file
       shell: bash
 
-    #- name: Post Plan
-    #  if: always() && github.ref != 'refs/heads/main' && steps.plan.outcome == 'success' || steps.plan.outcome == 'failure'
-    #  uses: Jimdo/terraform-pr-commenter@v1.6.0
-    #  with:
-    #    commenter_type: plan
-    #    commenter_input: ${{ format('{0}{1}', steps.plan.outputs.stdout, steps.plan.outputs.stderr) }}
-    #    commenter_exitcode: ${{ steps.plan.outputs.exitcode }}
-    #    commenter_comment: "Environment: ${{ env.ENVIRONMENT }}"
+    - name: Post Plan
+     if: always() && github.ref != 'refs/heads/main' && steps.plan.outcome == 'success' || steps.plan.outcome == 'failure'
+     uses: Jimdo/terraform-pr-commenter@v1.6.0
+     with:
+       commenter_type: plan
+       commenter_input: ${{ format('{0}{1}', steps.plan.outputs.stdout, steps.plan.outputs.stderr) }}
+       commenter_exitcode: ${{ steps.plan.outputs.exitcode }}
+       commenter_comment: "Environment: ${{ env.ENVIRONMENT }}"


### PR DESCRIPTION
We disabled this last year when we had issues with plans and mongo. We have not had those issues since after we fixed the cause of them