### PR TITLE
Migration metadata

### DIFF
--- a/publish-db-migrations/action.yml
+++ b/publish-db-migrations/action.yml
@@ -71,7 +71,7 @@ runs:
 
           if git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- "${{ inputs.path }}"; then
             echo "No changes detected in '${{ inputs.path }}'. Nothing to publish."
-            echo "### No updates to ${{ inputs.path }} detected.\nNo new database migrations were published." >> "$GITHUB_STEP_SUMMARY"
+            echo "No new database migrations were published, ${{ inputs.path }} was not updated" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           else
             echo "Changes detected in '${{ inputs.path }}'. Proceeding with upload."
@@ -84,14 +84,29 @@ runs:
         mkdir -p output
         tar -cvzf output/migrations.tgz "${{ inputs.path }}"
 
-        # Upload it to S3
-
+        # Get the version
         VERSION_TAG="${{ inputs.version }}"
         if [ -z "$VERSION_TAG" ]; then
           VERSION_TAG="${{ steps.version.outputs.tag }}"
         fi
+      
+        # Generate metadata
+        sha256=$(sha256sum output/migrations.tgz | awk '{print $1}')
+        commit=$(git log -n 1 --pretty=format:%H --)
+        jq -n --argjson files "$(find ./changelog -type f -printf '%P\n' | jq -R . | jq -s .)" \
+              --arg version "${VERSION_TAG}" \
+              --arg sha256 "${sha256}" \
+              --arg date "$(date -Is)" \
+              --arg commit "${commit}" \
+              --arg path "${{ inputs.path }} \
+              --arg format "db-migration-metadata:1.0.0"
+              '{format: $format, files: $files, version: $version, sha256: $sha256, date: $date, path: $path, commit: $commit}' > migrations.metadata.json
+
+        # Upload it to S3
+
 
         echo "Publishing schema version ${VERSION_TAG}"
         aws s3 cp output/migrations.tgz "s3://${{ inputs.bucket }}/${{ inputs.service-name }}/${VERSION_TAG}/migrations.tgz"
-        echo "### Published new database schema migration\nVersion: \`${VERSION_TAG}\`" >> "$GITHUB_STEP_SUMMARY"
+        aws s3 cp output/migrations.metadata.json "s3://${{ inputs.bucket }}/${{ inputs.service-name }}/${VERSION_TAG}/migrations.metadata.json"
+        echo "Published new database schema migration (Version: \`${VERSION_TAG}\`)" >> "$GITHUB_STEP_SUMMARY"
 

--- a/publish-db-migrations/action.yml
+++ b/publish-db-migrations/action.yml
@@ -83,7 +83,7 @@ runs:
         # Create the migrations archive
         mkdir -p output
         migrations_file=output/migrations.tgz
-        tar -cvzf migrations_file "${{ inputs.path }}"
+        tar -cvzf "${migrations_file}" "${{ inputs.path }}"
 
         # Get the version
         VERSION_TAG="${{ inputs.version }}"

--- a/publish-db-migrations/action.yml
+++ b/publish-db-migrations/action.yml
@@ -82,7 +82,8 @@ runs:
 
         # Create the migrations archive
         mkdir -p output
-        tar -cvzf output/migrations.tgz "${{ inputs.path }}"
+        migrations_file=output/migrations.tgz
+        tar -cvzf migrations_file "${{ inputs.path }}"
 
         # Get the version
         VERSION_TAG="${{ inputs.version }}"
@@ -94,6 +95,8 @@ runs:
         sha256=$(sha256sum output/migrations.tgz | awk '{print $1}')
         commit=$(git log -n 1 --pretty=format:%H --)
         changeset_files="$(find ${{ inputs.path }} -type f -printf '%P\n' | jq -R . | jq -s .)"
+        metadata_file=output/migrations.metadata.json
+
         jq -n --argjson files "${changeset_files}" \
               --arg version "${VERSION_TAG}" \
               --arg sha256 "${sha256}" \
@@ -101,13 +104,13 @@ runs:
               --arg commit "${commit}" \
               --arg path "${{ inputs.path }}" \
               --arg format "db-migration-metadata:1.0.0" \
-              '{format: $format, files: $files, version: $version, sha256: $sha256, date: $date, path: $path, commit: $commit}' > migrations.metadata.json
+              '{format: $format, files: $files, version: $version, sha256: $sha256, date: $date, path: $path, commit: $commit}' > "${metadata_file}"
 
         # Upload it to S3
 
 
         echo "Publishing schema version ${VERSION_TAG}"
-        aws s3 cp output/migrations.tgz "s3://${{ inputs.bucket }}/${{ inputs.service-name }}/${VERSION_TAG}/migrations.tgz"
-        aws s3 cp output/migrations.metadata.json "s3://${{ inputs.bucket }}/${{ inputs.service-name }}/${VERSION_TAG}/migrations.metadata.json"
+        aws s3 cp "${migrations_file}" "s3://${{ inputs.bucket }}/${{ inputs.service-name }}/${VERSION_TAG}/migrations.tgz"
+        aws s3 cp "${metadata_file}" "s3://${{ inputs.bucket }}/${{ inputs.service-name }}/${VERSION_TAG}/migrations.metadata.json"
         echo "Published new database schema migration (Version: \`${VERSION_TAG}\`)" >> "$GITHUB_STEP_SUMMARY"
 

--- a/publish-db-migrations/action.yml
+++ b/publish-db-migrations/action.yml
@@ -98,6 +98,7 @@ runs:
         metadata_file=output/migrations.metadata.json
 
         jq -n --argjson files "${changeset_files}" \
+              --arg changelog "db.changelog.xml" \
               --arg version "${VERSION_TAG}" \
               --arg sha256 "${sha256}" \
               --arg date "$(date -Is)" \

--- a/publish-db-migrations/action.yml
+++ b/publish-db-migrations/action.yml
@@ -63,7 +63,7 @@ runs:
         echo "Directory '${{ inputs.path }}' exists and contains at least one file."
 
         # Check if there eare any changes in this commit
-        if [ ${{ inputs.force }} == false ]; then
+        if [ ${{ inputs.force }} == "false" ]; then
           echo "Checking for changes in '${{ inputs.path }}'..."
 
           git fetch --unshallow || true
@@ -93,13 +93,14 @@ runs:
         # Generate metadata
         sha256=$(sha256sum output/migrations.tgz | awk '{print $1}')
         commit=$(git log -n 1 --pretty=format:%H --)
-        jq -n --argjson files "$(find ./changelog -type f -printf '%P\n' | jq -R . | jq -s .)" \
+        changeset_files="$(find ${{ inputs.path }} -type f -printf '%P\n' | jq -R . | jq -s .)"
+        jq -n --argjson files "${changeset_files}" \
               --arg version "${VERSION_TAG}" \
               --arg sha256 "${sha256}" \
               --arg date "$(date -Is)" \
               --arg commit "${commit}" \
-              --arg path "${{ inputs.path }} \
-              --arg format "db-migration-metadata:1.0.0"
+              --arg path "${{ inputs.path }}" \
+              --arg format "db-migration-metadata:1.0.0" \
               '{format: $format, files: $files, version: $version, sha256: $sha256, date: $date, path: $path, commit: $commit}' > migrations.metadata.json
 
         # Upload it to S3


### PR DESCRIPTION
Publishes a `migrations.metadata.json` file that contains

```
{
  "format": "db-migration-metadata:1.0.0",
  "files": [
    "db.changelog-1.10.xml",
    "db.changelog-1.0.xml",
    "db.changelog-1.9.xml",
    "db.changelog-1.11.xml",
    "db.changelog-1.12.xml",
    "db.changelog-1.16.xml",
    "db.changelog-1.2.xml",
    "db.changelog-1.1.xml",
    "db.changelog-1.8.xml",
    "db.changelog-1.4.xml",
    "db.changelog-1.14.xml",
    "db.changelog-1.15.xml",
    "db.changelog-1.6.xml",
    "db.changelog-1.3.xml",
    "db.changelog.xml",
    "db.changelog-1.5.xml",
    "db.changelog-1.17.xml",
    "db.changelog-1.13.xml",
    "db.changelog-1.7.xml"
  ],
  "version": "0.25.0",
  "sha256": "8e5eb2dc98788d8e3ca7f92eb1cf25840bf4717b226028f426a910797450986f",
  "date": "2025-05-10T17:14:54+00:00",
  "path": "./changelog",
  "commit": "9caacf310b761cea894a19abd093cf66c99e4192"
}
```

This would give us an idea of what's in the migration package, where/what commit created it, a checksum if we want to validate it down the line etc. 
Potentially we can include anything that's knowable at build-time