### PR TITLE
CORE-363 output whether terraform plan includes changes or not

### DIFF
--- a/tf-build/plan/action.yml
+++ b/tf-build/plan/action.yml
@@ -7,6 +7,11 @@ inputs:
     required: false
     default: '.'
 
+outputs:
+  has_changes:
+    description: 'Whether terraform plan shows changes'
+    value: ${{ steps.plan.outputs.has_changes  }}
+
 runs:
   using: "composite"
   steps:

--- a/tf-build/plan/plan.sh
+++ b/tf-build/plan/plan.sh
@@ -20,6 +20,13 @@ else
   echo "plan_is_large=false" >> "$GITHUB_OUTPUT"
 fi
 
+# We cannot use detailed-exitcode to see if there are no changes due to https://github.com/hashicorp/setup-terraform/issues/328
+if (terraform show "${ENVIRONMENT}.plan.file" |  grep -q "No changes."); then
+  echo "has_changes=false" >> "$GITHUB_OUTPUT"
+else
+  echo "has_changes=true" >> "$GITHUB_OUTPUT"
+fi
+
 {
   printf "plan_text<<PLAN_OUTPUT\n"
   cat "${ENVIRONMENT}.tf_plan.txt"


### PR DESCRIPTION
What did we do?
--

Added an output that we can use in GitHub workflows to determine whether the plan has changes or not. Then we can decide to skip uploading the plan and skip trying to do a terraform apply

Note that we would ideally use [-detailed-exitcode](https://developer.hashicorp.com/terraform/cli/commands/plan#detailed-exitcode) to test if there are changes in the plan, but there is a [known issue](https://github.com/hashicorp/setup-terraform/issues/328) with setup-terraform which uses a wrapper and suppresses exit code 2

Evidence of work
--

See [action](https://github.com/DEFRA/cdp-tf-core/actions/runs/16285458115/job/45983188813?pr=1318) from PR in cdp-tf-core using this branch, we skip uploading the plan if there are no changes, but there are changes in infra-dev so a plan is attached:

infra-dev, plan stored as it has changes:
<img width="324" height="509" alt="image" src="https://github.com/user-attachments/assets/246d8de7-d9bc-485c-8660-e3bbce847755" />

dev, store plan skipped as it has no changes:
<img width="292" height="385" alt="image" src="https://github.com/user-attachments/assets/6f820ffa-af09-4f35-a64a-d1dcd43fc78e" />
