### PR TITLE
CORE-908 remove references to old resources folder

### DIFF
--- a/tf-build/elasticache-redis/action.yml
+++ b/tf-build/elasticache-redis/action.yml
@@ -8,23 +8,13 @@ inputs:
   targetEnv:
     description: The target environment for the tenant_services.json
     required: true
-  mergeJsonFiles:
-    description: "Merge JSON files to create tenant_services.json"
-    required: false
-    default: false
 runs:
   using: "composite"
   steps:
-    - name: Check if JSON merge needed
-      id: check_merge
-      shell: bash
-      run: echo "merge=${{ inputs.mergeJsonFiles }}" >> $GITHUB_ENV
-
     - name: Construct merged_tenant_services.json from multiple files
-      if: ${{ env.merge == 'true' }}
       shell: bash
       run: |
-        merged_file=environments/${{ inputs.targetEnv }}/resources/merged_tenant_services.json
+        merged_file=environments/${{ inputs.targetEnv }}/merged_tenant_services.json
         echo "[" > $merged_file
 
         first=true
@@ -44,10 +34,7 @@ runs:
       shell: bash
       run: |
         message_id=$(uuidgen)
-        json_file="environments/${{ inputs.targetEnv }}/resources/tenant_services.json"
-        if [[ ${{ env.merge }} == 'true' ]]; then
-          json_file="environments/${{ inputs.targetEnv }}/resources/merged_tenant_services.json"
-        fi
+        json_file="environments/${{ inputs.targetEnv }}/merged_tenant_services.json"
         aws sns publish --topic-arn ${{ inputs.topicArn }}  --message-attributes \
         '{"environment" : { "DataType":"String", "StringValue":"${{ inputs.targetEnv }}"}}' \
         --message file://$json_file \

--- a/tf-build/mongo/action.yml
+++ b/tf-build/mongo/action.yml
@@ -4,25 +4,15 @@ description: "Triggers update of mongo user roles"
 inputs:
   topicArn:
     description: Which sns topic to send the message to
-  mergeJsonFiles:
-    description: "Merge JSON files to create tenant_services.json"
-    required: false
-    default: false
 
 runs:
   using: "composite"
   steps:
-    - name: Check if JSON merge needed
-      id: check_merge
-      shell: bash
-      run: echo "merge=${{ inputs.mergeJsonFiles }}" >> $GITHUB_ENV
-
     - name: Construct merged_tenant_services.json from multiple files
-      if: ${{ env.merge == 'true' }}
       shell: bash
       run: |
         echo "Construct merged_tenant_services.json from multiple files"
-        merged_file=environments/${{ env.ENVIRONMENT }}/resources/merged_tenant_services.json
+        merged_file=environments/${{ env.ENVIRONMENT }}/merged_tenant_services.json
         echo "[{" > $merged_file
 
         first=true
@@ -41,9 +31,6 @@ runs:
     - name: Update Mongodb Users
       shell: bash
       run: |
-        json_file="environments/${{ env.ENVIRONMENT }}/resources/tenant_services.json"
-        if [[ ${{ env.merge }} == 'true' ]]; then
-          json_file="environments/${{ env.ENVIRONMENT }}/resources/merged_tenant_services.json"
-        fi
+        json_file="environments/${{ env.ENVIRONMENT }}/merged_tenant_services.json"
         echo "Updating users with ${json_file}"
         aws sns publish --topic-arn ${{ inputs.topicArn }} --message file://${json_file}

--- a/tf-build/secrets-manager/action.yml
+++ b/tf-build/secrets-manager/action.yml
@@ -8,24 +8,14 @@ inputs:
   targetEnv:
     description: The target environment for the tenant_services.json
     required: true
-  mergeJsonFiles:
-    description: "Merge JSON files to create tenant_services.json"
-    required: false
-    default: false
 
 runs:
   using: "composite"
   steps:
-    - name: Check if JSON merge needed
-      id: check_merge
-      shell: bash
-      run: echo "merge=${{ inputs.mergeJsonFiles }}" >> $GITHUB_ENV
-
     - name: Construct merged_tenant_services.json from multiple files
-      if: ${{ env.merge == 'true' }}
       shell: bash
       run: |
-        merged_file=environments/${{ inputs.targetEnv }}/resources/merged_tenant_services.json
+        merged_file=environments/${{ inputs.targetEnv }}/merged_tenant_services.json
         echo "[" > $merged_file
 
         first=true
@@ -45,10 +35,7 @@ runs:
       shell: bash
       run: |
         message_id=$(uuidgen)
-        json_file="environments/${{ inputs.targetEnv }}/resources/tenant_services.json"
-        if [[ ${{ env.merge }} == 'true' ]]; then
-          json_file="environments/${{ inputs.targetEnv }}/resources/merged_tenant_services.json"
-        fi
+        json_file="environments/${{ inputs.targetEnv }}/merged_tenant_services.json"
         aws sns publish --topic-arn ${{ inputs.topicArn }}  --message-attributes \
         '{"environment" : { "DataType":"String", "StringValue":"${{ inputs.targetEnv }}"}}' \
         --message file://$json_file \


### PR DESCRIPTION
What did we do?
--

Updates actions which generate a list of specific resources across all tenant files to a. no longer created the temporary file in the resources folder, which has now been removed, and b. no longer supports using the single tenant config which was removed a year ago

Evidence of work
--

Tested from branch in infra-dev:

<img width="480" height="299" alt="image" src="https://github.com/user-attachments/assets/bb30916c-149f-4b71-a762-9218f4136373" />

<img width="933" height="216" alt="image" src="https://github.com/user-attachments/assets/7ed8c6ad-bcba-4337-85f8-3c452473ff04" />
<img width="1227" height="98" alt="image" src="https://github.com/user-attachments/assets/37fad05e-e56b-49a2-a372-e80069ae967e" />
<img width="1227" height="337" alt="image" src="https://github.com/user-attachments/assets/3a657836-3daa-47f1-842c-f1edca2a9172" />
