### PR TITLE
CORE-2531 add action to unit test a lambda using tox

### DIFF
--- a/lambda-build/unit-test-tox/action.yml
+++ b/lambda-build/unit-test-tox/action.yml
@@ -1,0 +1,27 @@
+name: Unit test a lambda function with tox
+description: 'Unit test the lambda function with tox'
+inputs:
+  python_version:
+    description: The python version to use
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ inputs.python_version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python_version }}
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+
+    - name: Test with tox
+      shell: bash
+      run: tox


### PR DESCRIPTION
Added an action to unit test a lambda using tox. We currently have unit-test as it's own workflow and when that succeeds on main, the env-build workflow gets triggered. We want to be able to trigger env-build using a workflow dispatch which wouldn't work due to the requirement on the unit tests passing. Making this a reusable action means we can call unit tests both on a PR workflow and at the start of the env build workflow

Tested with slack-notifications-lambda
<img width="711" height="382" alt="image" src="https://github.com/user-attachments/assets/b9fb644a-a7a1-4f24-8039-f2c9630d055e" />
