### PR TITLE
CORE-2587 Bump deprecated versions to use NODE24

### DIFF
--- a/docker-login/action.yml
+++ b/docker-login/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-region: ${{ inputs.aws-region }}
         role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/${{ inputs.iam-role-name }}
@@ -29,7 +29,7 @@ runs:
 
     # Get Docker secrets from Secrets Manager
     - name: Get Github Actions secrets from Secrets Manager
-      uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      uses: aws-actions/aws-secretsmanager-get-secrets@v3
       with:
         secret-ids: |
           ,${{ inputs.secret-manager-docker-credentials }}

--- a/get-github-token/action.yml
+++ b/get-github-token/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
     # Setup exectuion for AWS
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.role_to_assume }}
@@ -36,7 +36,7 @@ runs:
 
     # Get the private git
     - name: Get Github app private key from ASM
-      uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      uses: aws-actions/aws-secretsmanager-get-secrets@v3
       with:
         secret-ids: |
           PRIVATE_KEY, ${{ inputs.private_key_id }}

--- a/lambda-build/publish/action.yml
+++ b/lambda-build/publish/action.yml
@@ -21,7 +21,7 @@ runs:
     - uses: actions/checkout@v4
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.role_to_assume }}

--- a/publish-db-migrations/action.yml
+++ b/publish-db-migrations/action.yml
@@ -30,7 +30,7 @@ runs:
   steps:
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-region: ${{ env.AWS_REGION }}
         role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github-${{ inputs.service-name }}-build-role

--- a/tf-build/init/action.yml
+++ b/tf-build/init/action.yml
@@ -48,7 +48,7 @@ runs:
 
     # Install Terraform CLI pinned version
     - name: Terraform - setup
-      uses: hashicorp/setup-terraform@v4.0.0
+      uses: hashicorp/setup-terraform@v4
       with:
         terraform_version: "1.12.2"
 

--- a/tf-build/init/action.yml
+++ b/tf-build/init/action.yml
@@ -48,7 +48,7 @@ runs:
 
     # Install Terraform CLI pinned version
     - name: Terraform - setup
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@v4.0.0
       with:
         terraform_version: "1.12.2"
 

--- a/tf-build/secrets/action.yml
+++ b/tf-build/secrets/action.yml
@@ -51,7 +51,7 @@ runs:
     # Github auth using Github App - environment variables are set by previosu step action
     - name: get gh token from cdp-gh-action
       id: cdp-gh-action
-      uses: getsentry/action-github-app-token@v4.0.0
+      uses: getsentry/action-github-app-token@v5c1e90706fe007857338ac1bfbd7a4177db2f789 # this is 4.0.0 commit hash
       with:
         app_id: ${{ env.CDP_PLATFORM_GH_ACTIONS_CDP_GH_APP_ID }}
         private_key: ${{ env.CDP_GH_APP_PRIV_KEY }}

--- a/tf-build/secrets/action.yml
+++ b/tf-build/secrets/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     # Setup exectuion for AWS
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-region: ${{ env.AWS_REGION }}
         role-to-assume: ${{ inputs.role_to_assume }}
@@ -28,7 +28,7 @@ runs:
 
     # Get Github actions secrets from ASM
     - name: Get Github actions secrets from ASM
-      uses: aws-actions/aws-secretsmanager-get-secrets@v3.0.1
+      uses: aws-actions/aws-secretsmanager-get-secrets@v3
       with:
         secret-ids: |
           ${{ inputs.gh_actions_secrets }}
@@ -36,7 +36,7 @@ runs:
 
       # Get Github app private key from ASM
     - name: Get Github app private key from ASM
-      uses: aws-actions/aws-secretsmanager-get-secrets@v3.0.1
+      uses: aws-actions/aws-secretsmanager-get-secrets@v3
       with:
         secret-ids: |
           ${{ inputs.gh_app_private_key }}

--- a/tf-build/secrets/action.yml
+++ b/tf-build/secrets/action.yml
@@ -28,7 +28,7 @@ runs:
 
     # Get Github actions secrets from ASM
     - name: Get Github actions secrets from ASM
-      uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      uses: aws-actions/aws-secretsmanager-get-secrets@v3.0.1
       with:
         secret-ids: |
           ${{ inputs.gh_actions_secrets }}
@@ -36,7 +36,7 @@ runs:
 
       # Get Github app private key from ASM
     - name: Get Github app private key from ASM
-      uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      uses: aws-actions/aws-secretsmanager-get-secrets@v3.0.1
       with:
         secret-ids: |
           ${{ inputs.gh_app_private_key }}
@@ -51,7 +51,7 @@ runs:
     # Github auth using Github App - environment variables are set by previosu step action
     - name: get gh token from cdp-gh-action
       id: cdp-gh-action
-      uses: getsentry/action-github-app-token@v2
+      uses: getsentry/action-github-app-token@v4.0.0
       with:
         app_id: ${{ env.CDP_PLATFORM_GH_ACTIONS_CDP_GH_APP_ID }}
         private_key: ${{ env.CDP_GH_APP_PRIV_KEY }}


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use the latest versions of key third-party actions, primarily for AWS credentials management, secrets retrieval, and Terraform setup. These upgrades improve security, maintainability, and compatibility with the latest features and bug fixes.

**Dependency upgrades for AWS and Terraform actions:**

* Updated all usages of `aws-actions/configure-aws-credentials` from version `v4` to `v6` in the following workflow files: `docker-login/action.yml`, `get-github-token/action.yml`, `lambda-build/publish/action.yml`, `publish-db-migrations/action.yml`, and `tf-build/secrets/action.yml`. [[1]](diffhunk://#diff-87e3c56cdebc06bdbc233ef4da87b934a7fba539af0873b17b81466e92fbe2fdL22-R22) [[2]](diffhunk://#diff-1bcaa1b780cfbd9ed36cf0a1a5f3890de1e11c0c9acddfe5d1d7db668a5e8bedL30-R30) [[3]](diffhunk://#diff-731c83e7859c630ac44989d2ea79a63fee17559d8bcea84f14adbcfd9a3c4955L24-R24) [[4]](diffhunk://#diff-9c3fcb98170a2811145ccc3792b5ff835776b3358194f8e3eac56f2d2106a282L33-R33) [[5]](diffhunk://#diff-a0d0440a12306853117f0a30204b3dc127235dafc26b0223b6fd8d495dd3d214L22-R22)
* Updated all usages of `aws-actions/aws-secretsmanager-get-secrets` from version `v2` to `v3` in: `docker-login/action.yml`, `get-github-token/action.yml`, and `tf-build/secrets/action.yml`. [[1]](diffhunk://#diff-87e3c56cdebc06bdbc233ef4da87b934a7fba539af0873b17b81466e92fbe2fdL32-R32) [[2]](diffhunk://#diff-1bcaa1b780cfbd9ed36cf0a1a5f3890de1e11c0c9acddfe5d1d7db668a5e8bedL39-R39) [[3]](diffhunk://#diff-a0d0440a12306853117f0a30204b3dc127235dafc26b0223b6fd8d495dd3d214L31-R39)
* Upgraded `hashicorp/setup-terraform` from `v3` to `v4` in `tf-build/init/action.yml`.
* Updated `getsentry/action-github-app-token` from `v2` to `v4.0.0` in `tf-build/secrets/action.yml`.