### PR TITLE
CORE 2587 composite checkout and checkov action

### DIFF
--- a/checkout/README.md
+++ b/checkout/README.md
@@ -1,0 +1,86 @@
+# Centralized Checkout Action
+
+A centralized wrapper around [actions/checkout](https://github.com/actions/checkout) that manages versions and defaults in one place across all CDP pipelines.
+
+## Purpose
+
+This action provides a single point of control for checkout operations across all CDP workflows. Instead of directly using `actions/checkout` in multiple pipelines, use this wrapper to:
+
+- **Centralize version management**: Update the `actions/checkout` version once here instead of across dozens of workflows
+- **Enforce consistent defaults**: Apply standard configurations (like defaulting to `main` branch) across all pipelines
+- **Simplify updates**: When GitHub updates `actions/checkout`, update it once here and all pipelines benefit
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `fetch-depth` | Number of commits to fetch. `0` indicates all history for full clone | No | `1` |
+| `path` | Relative path under `$GITHUB_WORKSPACE` to place the repository | No | `''` (root) |
+| `ref` | The branch, tag or SHA to checkout | No | `main` |
+
+## Usage
+
+### Basic Usage
+
+Checkout the repository with default settings (single commit from `main` branch):
+
+```yaml
+- name: Checkout code
+  uses: ./cdp-build-action/checkout
+```
+
+### Checkout a Specific Branch
+
+```yaml
+- name: Checkout feature branch
+  uses: ./cdp-build-action/checkout
+  with:
+    ref: feature/my-feature
+```
+
+### Full History Clone
+
+Fetch complete git history (useful for changelog generation or git-based versioning):
+
+```yaml
+- name: Checkout with full history
+  uses: ./cdp-build-action/checkout
+  with:
+    fetch-depth: 0
+```
+
+### Checkout to Custom Path
+
+Place the repository in a subdirectory:
+
+```yaml
+- name: Checkout to custom location
+  uses: ./cdp-build-action/checkout
+  with:
+    path: my-repo
+```
+
+### Combined Options
+
+```yaml
+- name: Checkout specific tag with history
+  uses: ./cdp-build-action/checkout
+  with:
+    ref: v1.2.3
+    fetch-depth: 0
+    path: releases/v1.2.3
+```
+
+## Maintenance
+
+To update the underlying `actions/checkout` version:
+
+1. Edit `action.yml`
+2. Update the version in the `uses:` statement (currently `v5`)
+3. Commit and push changes
+4. All pipelines using this wrapper will automatically use the new version
+
+## Related Documentation
+
+- [actions/checkout Documentation](https://github.com/actions/checkout)
+- [GitHub Actions Composite Actions Guide](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action)

--- a/checkout/action.yml
+++ b/checkout/action.yml
@@ -1,0 +1,26 @@
+name: 'Centralized Checkout'
+description: 'Wraps actions/checkout to manage versions and defaults in one place'
+
+inputs:
+  fetch-depth:
+    description: 'Number of commits to fetch. 0 indicates all history.'
+    required: false
+    default: '1'
+  path:
+    description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
+    required: false
+    default: ''
+  ref:
+    description: 'The branch, tag or SHA to checkout'
+    required: false
+    default: 'main' # Defaulting to main as requested
+
+runs:
+  using: "composite"
+  steps:
+    - name: Execute Checkout
+      uses: actions/checkout@v5 # Bump version here to update all pipelines using this action
+      with:
+        fetch-depth: ${{ inputs.fetch-depth }}
+        path: ${{ inputs.path }}
+        ref: ${{ inputs.ref }}

--- a/tf-build/checkov/README.md
+++ b/tf-build/checkov/README.md
@@ -1,0 +1,36 @@
+# Centralized Checkov Scan Action
+
+This composite action provides a standardized wrapper for the [Bridgecrew Checkov Action](https://github.com/bridgecrewio/checkov-action). It centralizes the versioning and default configuration for Infrastructure as Code (IaC) security scanning across all workflows in this repository.
+
+## Why Use This Action?
+
+* **Single Source of Truth:** Manage the Checkov version (`v12`) in one file rather than updating dozens of workflow files.
+* **Consistent Policy:** Ensures that the Prisma API URL, output formats, and framework settings are identical across the organization.
+* **Clean Workflows:** Reduces boilerplate code in your main CI/CD pipeline files.
+
+## Inputs
+
+| Input | Description | Required | Default |
+| :--- | :--- | :--- | :--- |
+| `quiet` | If set to `true`, only display failed checks. | No | `true` |
+| `framework` | The IaC framework to scan (e.g., `terraform`, `cloudformation`, `all`). | No | `terraform` |
+| `output_format` | The report format (`cli`, `json`, `sarif`). | No | `cli` |
+| `prisma-api-url` | The URL for the Prisma Cloud API endpoint. | No | `https://api0.prismacloud.io` |
+
+## Usage
+
+To use this action, simply reference its local path in your workflow. Ensure you have performed a checkout step before running the scan.
+
+```yaml
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: ./.github/actions/ui-checkout
+
+      - name: Run Checkov Scan
+        uses: ./.github/actions/tf-checkov
+        with:
+          framework: 'terraform'
+          quiet: true

--- a/tf-build/checkov/action.yml
+++ b/tf-build/checkov/action.yml
@@ -1,0 +1,32 @@
+name: 'Standardized Checkov Scan'
+description: 'Runs Checkov with centralized versioning and defaults'
+
+inputs:
+  quiet:
+    description: 'Only display failed checks'
+    required: false
+    default: 'true'
+  framework:
+    description: 'The framework to check'
+    required: false
+    default: 'terraform'
+  output_format:
+    description: 'The output format (cli, json, sarif, etc.)'
+    required: false
+    default: 'cli'
+  prisma-api-url:
+    description: 'The Prisma Cloud API URL'
+    required: false
+    default: 'https://api0.prismacloud.io'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Terraform - checkov
+      id: checkov
+      uses: bridgecrewio/checkov-action@v12 # VERSION MANAGED HERE
+      with:
+        quiet: ${{ inputs.quiet }}
+        framework: ${{ inputs.framework }}
+        output_format: ${{ inputs.output_format }}
+        prisma-api-url: ${{ inputs.prisma-api-url }}


### PR DESCRIPTION
This pull request introduces two new centralized GitHub Actions for the repository: a centralized wrapper for `actions/checkout` and a standardized wrapper for running Checkov scans. These actions are designed to centralize version management, enforce consistent defaults, and simplify updates across all CDP pipelines.

**Centralized Checkout Action:**

- Adds a composite action `checkout/action.yml` that wraps `actions/checkout` with centralized version control and default inputs for `fetch-depth`, `path`, and `ref` (defaulting to `main`). This makes it easier to update the checkout version and maintain consistent settings across pipelines.
- Provides comprehensive documentation in `checkout/README.md` explaining usage, purpose, input options, and maintenance instructions for the centralized checkout action.

**Standardized Checkov Scan Action:**

- Introduces `tf-build/checkov/action.yml`, a composite action that wraps the `bridgecrewio/checkov-action` for running Checkov scans. It centralizes version management and provides default inputs for common options like `quiet`, `framework`, `output_format`, and `prisma-api-url`.This pull request introduces two new centralized composite GitHub Actions to standardize and simplify pipeline management: a wrapper for `actions/checkout` and a standardized Checkov scan action. These actions centralize version management, enforce consistent defaults, and make updates easier across all workflows. Comprehensive documentation is included for the checkout action.

**Centralized Checkout Action**

- Added `checkout/action.yml`, a composite action wrapping `actions/checkout`, centralizing version and default management.
- Included `checkout/README.md` with detailed usage instructions, input descriptions, and maintenance guidelines for the checkout action.

**Standardized Checkov Scan Action**

- Added `tf-build/checkov/action.yml`, a composite action wrapping `bridgecrewio/checkov-action` with centralized versioning and default input values for Checkov scans.This pull request introduces a new centralized GitHub Action for repository checkout operations, aiming to standardize and simplify how code is checked out across all CDP pipelines. The action wraps `actions/checkout`, centralizes version management, enforces consistent defaults, and streamlines future updates.

**Centralized Checkout Action Implementation:**

* Added a composite action in `checkout/action.yml` that wraps `actions/checkout@v5`, exposing configurable inputs (`fetch-depth`, `path`, and `ref`) with sensible defaults (e.g., default branch set to `main`). This allows all pipelines to reference a single, updatable checkout configuration.

**Documentation:**

* Added a comprehensive `checkout/README.md` explaining the purpose, usage examples, input parameters, and maintenance instructions for the new centralized checkout action. This ensures clarity for all users and maintainers.
