### PR TITLE
Add action for download artifact

### DIFF
--- a/tf-build/download-plan/README.md
+++ b/tf-build/download-plan/README.md
@@ -1,0 +1,84 @@
+# Get Plan Artifact
+
+Downloads a Terraform plan artifact from a PR workflow for use in subsequent workflows.
+
+## Description
+
+This composite action downloads a previously generated Terraform plan file artifact from a pull request workflow. It's designed to work as part of a Terraform deployment pipeline where plans are generated during PR validation and then applied after approval.
+
+## Inputs
+
+### `pr_number`
+
+**Required**: Yes
+
+The pull request number to fetch the artifact from. This should be the PR number where the plan was originally generated.
+
+### `environment`
+
+**Required**: Yes
+
+The environment name (e.g., `dev`, `prod`, `test`). This is used to construct the artifact name as `{environment}.plan.file`.
+
+## Usage
+
+### Basic Example
+
+```yaml
+- name: Download Terraform Plan
+  uses: ./tf-build/download-plan
+  with:
+    pr_number: ${{ github.event.pull_request.number }}
+    environment: dev
+```
+
+### Conditional Download
+
+The action automatically skips the download step if `pr_number` is empty:
+
+```yaml
+- name: Download Terraform Plan
+  uses: ./tf-build/download-plan
+  with:
+    pr_number: ${{ github.event.pull_request.number || '' }}
+    environment: prod
+```
+
+### In a Deployment Workflow
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get Terraform Plan
+        uses: ./tf-build/download-plan
+        with:
+          pr_number: ${{ github.event.number }}
+          environment: production
+
+      - name: Apply Terraform Plan
+        run: terraform apply production.plan.file
+```
+
+## How It Works
+
+1. The action looks for artifacts from the `pull-request.yml` workflow
+2. It searches for an artifact named `{environment}.plan.file`
+3. Downloads the artifact to the current directory (`.`)
+4. If no artifact is found, the action continues without failing (`if_no_artifact_found: ignore`)
+
+## Dependencies
+
+This action uses:
+- [DEFRA/cdp-action-download-artifact@v20](https://github.com/DEFRA/cdp-action-download-artifact)
+
+## Notes
+
+- The action will gracefully skip if no PR number is provided
+- Artifacts are downloaded to the current working directory
+- If the artifact doesn't exist, the workflow will continue (no failure)
+- The artifact name must match the pattern: `{environment}.plan.file`

--- a/tf-build/download-plan/action.yml
+++ b/tf-build/download-plan/action.yml
@@ -1,0 +1,25 @@
+name: 'Get Plan Artifact'
+description: 'Downloads a Terraform plan artifact from a PR workflow'
+
+inputs:
+  pr_number:
+    description: 'The PR number to fetch artifacts from'
+    required: true
+  environment:
+    description: 'The environment name (e.g., dev, prod)'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download Artifact
+      id: download
+      # The 'if' condition works inside composite actions to skip the step if no PR exists
+      if: ${{ inputs.pr_number != '' }}
+      uses: DEFRA/cdp-action-download-artifact@v20 # change this to the correct version of the action
+      with:
+        workflow: pull-request.yml
+        pr: ${{ inputs.pr_number }}
+        name: ${{ inputs.environment }}.plan.file
+        path: .
+        if_no_artifact_found: ignore

--- a/tf-build/download-plan/action.yml
+++ b/tf-build/download-plan/action.yml
@@ -9,6 +9,12 @@ inputs:
     description: 'The environment name (e.g., dev, prod)'
     required: true
 
+outputs:
+  found_artifact:
+    description: "Returns 'true' if the artifact was successfully downloaded"
+    # Map the internal step output to the action output
+    value: ${{ steps.download.outputs.found_artifact }}
+
 runs:
   using: "composite"
   steps:

--- a/tf-build/find-pr/action.yml
+++ b/tf-build/find-pr/action.yml
@@ -8,7 +8,7 @@ inputs:
     default: 'all'
 
 outputs:
-  pr-number:
+  number:
     description: 'The number of the found pull request'
     value: ${{ steps.findPr.outputs.number }}
 

--- a/tf-build/find-pr/action.yml
+++ b/tf-build/find-pr/action.yml
@@ -1,0 +1,22 @@
+name: 'Find Current Pull Request'
+description: 'Locates the current PR and returns its number'
+
+inputs:
+  state:
+    description: 'The state of the PR to look for (e.g., open, closed, all)'
+    required: false
+    default: 'all'
+
+outputs:
+  pr-number:
+    description: 'The number of the found pull request'
+    value: ${{ steps.findPr.outputs.number }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Find PR
+      id: findPr
+      uses: DEFRA/cdp-gh-find-current-pr@v1.3.5 # Managed version
+      with:
+        state: ${{ inputs.state }}


### PR DESCRIPTION
This pull request introduces a new composite GitHub Action, `Get Plan Artifact`, for downloading Terraform plan artifacts generated in pull request workflows. This action is intended to streamline deployment pipelines by enabling subsequent workflows (such as apply jobs) to retrieve and use the correct Terraform plan files.

**New composite action for downloading Terraform plan artifacts:**

* Added `tf-build/download-plan/action.yml` to define the composite action, which downloads a Terraform plan artifact for a specified PR and environment using `DEFRA/cdp-action-download-artifact@v20`.
* Added comprehensive documentation in `tf-build/download-plan/README.md`, including usage instructions, input descriptions, and workflow integration examples.
