### PR TITLE
CORE-2587 Add upload artifact

### DIFF
--- a/tf-build/upload-plan/action.yml
+++ b/tf-build/upload-plan/action.yml
@@ -1,0 +1,18 @@
+name: 'Upload Plan Artifact'
+description: 'Uploads a Terraform plan artifact from a PR workflow'
+
+inputs:
+  environment:
+    description: 'The environment name (e.g., dev, prod)'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Upload Plan Artifact
+      id: upload
+      uses: actions/upload-artifact@v7.0.1 # Upgrade version here to update all pipelines using this action
+      with:
+        name: ${{ inputs.environment }}.plan.file
+        path: ${{ inputs.environment }}.plan.file
+        retention-days: 1


### PR DESCRIPTION
This pull request introduces a new composite GitHub Action for uploading Terraform plan artifacts in PR workflows. The action allows specifying the environment and uses an updated version of the `actions/upload-artifact` action.

**New GitHub Action for Terraform Plan Uploads:**

* Added `tf-build/upload-plan/action.yml` to define a composite action that uploads a Terraform plan artifact based on the provided environment name and sets artifact retention to 1 day. The action uses `actions/upload-artifact@v7.0.1` for improved reliability and consistency across pipelines.