### PR TITLE
Update version call in other areas

### DIFF
--- a/lambda-build/build/action.yml
+++ b/lambda-build/build/action.yml
@@ -29,7 +29,7 @@ runs:
         FUNCTION_NAME: ${{ inputs.function_name }}
 
     - name: Store lambda artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1 # Upgrade version here to update all pipelines using this action
       with:
         if-no-files-found: error
         name: ${{ inputs.function_name }}.zip
@@ -37,7 +37,7 @@ runs:
         retention-days: 1
 
     - name: Store lambda hash file
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1 # Upgrade version here to update all pipelines using this action
       with:
         if-no-files-found: error
         name: ${{ inputs.function_name }}.zip.base64sha256

--- a/lambda-build/publish/action.yml
+++ b/lambda-build/publish/action.yml
@@ -28,14 +28,14 @@ runs:
 
     - name: Get lambda artifact
       id: get_lambda_artifact
-      uses: actions/download-artifact@v5
+      uses: DEFRA/cdp-action-download-artifact@v20
       with:
         name: ${{ inputs.function_name }}.zip
         path: ./output/
 
     - name: Get lambda hash file
       id: get_lambda_hash
-      uses: actions/download-artifact@v5
+      uses: DEFRA/cdp-action-download-artifact@v20
       with:
         name: ${{ inputs.function_name }}.zip.base64sha256
         path: ./output/

--- a/tf-build/init/action.yml
+++ b/tf-build/init/action.yml
@@ -36,7 +36,7 @@ runs:
 
     - name: Restore terraform cached modules
       if: inputs.use_persisted_modules == 'true'
-      uses: actions/download-artifact@v6
+      uses: DEFRA/cdp-action-download-artifact@v20
       with:
         name: terraform-dir
         path: .terraform
@@ -62,7 +62,7 @@ runs:
     - name: Persist terraform modules
       if: inputs.persist_modules == 'true' && steps.init.outcome == 'success'
       id: persists-terraform
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7.0.1 # Upgrade version here to update all pipelines using this action
       with:
         name: terraform-dir
         path: .terraform


### PR DESCRIPTION
This pull request updates the versions of GitHub Actions used for uploading and downloading artifacts in several workflow files. The main goal is to upgrade to newer versions and to standardize on a custom action for downloading artifacts, which should improve reliability and maintainability across all pipelines.

**Artifact upload action upgrades:**
- Updated `actions/upload-artifact` to version `v7.0.1` in `lambda-build/build/action.yml` and `tf-build/init/action.yml` for storing Lambda artifacts and Terraform modules, ensuring all pipelines use the latest version. [[1]](diffhunk://#diff-1798c58cd32974627cbc5c0f1f2a9d9ebe156c2c47fb565e0e6e7d7dc8bdf844L32-R40) [[2]](diffhunk://#diff-70bf85cfca3ac945bb509a2808abf7d7a157aa7072ac40620b323e47a729afbdL65-R65)

**Artifact download action standardization:**
- Replaced `actions/download-artifact` with `DEFRA/cdp-action-download-artifact@v20` in `lambda-build/publish/action.yml` and `tf-build/init/action.yml` for retrieving Lambda artifacts, hash files, and Terraform modules, standardizing on a custom, organization-maintained action. [[1]](diffhunk://#diff-731c83e7859c630ac44989d2ea79a63fee17559d8bcea84f14adbcfd9a3c4955L31-R38) [[2]](diffhunk://#diff-70bf85cfca3ac945bb509a2808abf7d7a157aa7072ac40620b323e47a729afbdL39-R39)