### PR TITLE
CORE-2587 Add setup-uv

### DIFF
--- a/setup-uv/action.yml
+++ b/setup-uv/action.yml
@@ -1,0 +1,15 @@
+name: 'Setup UV Environment'
+description: 'Installs uv, enables caching, and sets up Python'
+inputs:
+  enable-cache:
+    description: 'Whether to enable caching for uv'
+    required: false
+    default: 'true'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v8.1.0
+      with:
+        enable-cache: ${{ inputs.enable-cache }}


### PR DESCRIPTION
This pull request introduces a new GitHub Action configuration for setting up a UV environment. The action installs UV, supports optional caching, and sets up Python, making it easier to standardize Python environment setup in CI workflows.

New GitHub Action for Python environment setup:

* Added `setup-uv/action.yml` to define a composite GitHub Action that installs UV, enables caching by default (configurable via the `enable-cache` input), and sets up Python using the `astral-sh/setup-uv` action.