### PR TITLE
Bump version of 4.0.0

### DIFF
--- a/get-github-token/action.yml
+++ b/get-github-token/action.yml
@@ -44,7 +44,7 @@ runs:
     # Github auth using Github App - environment variables are set by previous step action
     - name: Get token
       id: get-token
-      uses: getsentry/action-github-app-token@v3
+      uses: getsentry/action-github-app-token@v4.0.0
       with:
         app_id: ${{ inputs.app_id }}
         private_key: ${{ env.PRIVATE_KEY }}


### PR DESCRIPTION
This pull request updates the GitHub Action used to obtain authentication tokens to a newer version for improved reliability and features.

### Note:
This new version is already being successfully used in [here](https://github.com/DEFRA/cdp-build-action/blob/cb0a59084ce4391ca93b6babb814b7f138f34df9/tf-build/secrets/action.yml#L54) 

Dependency update:

* Updated the `getsentry/action-github-app-token` action from version `v3` to `v4.0.0` in `get-github-token/action.yml` to ensure compatibility with the latest features and bug fixes.