### PR TITLE
Add action to kill all stuck workflows

### DIFF
--- a/workflow-reaper/README.md
+++ b/workflow-reaper/README.md
@@ -1,0 +1,39 @@
+# workflow-reaper
+
+A reusable GitHub Actions workflow that cancels workflow runs that have been queued or running longer than a configured threshold. Useful as a scheduled job to clean up stuck or abandoned runs across a repository.
+
+## What does it do?
+
+Queries all `queued` and `in_progress` workflow runs in the repository and cancels any that were created before the configured cutoff time. Requires `actions: write` permission to cancel runs.
+
+## Example usage
+
+Run on a schedule to automatically reap stuck workflows:
+
+```yaml
+on:
+  schedule:
+    - cron: '0 * * * *'  # every hour
+
+jobs:
+  reaper:
+    uses: defra-cdp-sandpit/cdp-build-action/.github/workflows/workflow-reaper.yml@main
+    with:
+      timeout_minutes: 120
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `timeout_minutes` | Cancel workflows that have been queued or running longer than this many minutes | No | `120` |
+
+## Permissions
+
+The calling workflow must grant the following permissions:
+
+```yaml
+permissions:
+  actions: write
+  contents: write
+```

--- a/workflow-reaper/action.yml
+++ b/workflow-reaper/action.yml
@@ -1,0 +1,45 @@
+name: Workflows Reaper
+
+on:
+  workflow_call:
+    inputs:
+      timeout_minutes:
+        description: 'Cancel workflows running or queued longer than this many minutes'
+        type: number
+        default: 120
+        required: false
+
+jobs:
+  terminate-stuck-runs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: write
+      contents: write
+
+    steps:
+      - name: Cancel long-running flows
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          CUTOFF_MINUTES: ${{ inputs.timeout_minutes || 120 }}
+        run: |
+          CUTOFF=$(date -u -d "${CUTOFF_MINUTES} minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+          echo "Cancelling runs older than: $CUTOFF (${CUTOFF_MINUTES} minutes ago)"
+
+          for STATUS in queued in_progress; do
+            echo "Checking $STATUS runs..."
+            IDS=$(gh run list \
+              --repo "$REPO" \
+              --status "$STATUS" \
+              --limit 100 \
+              --json databaseId,createdAt \
+              | jq -r ".[] | select(.createdAt < \"$CUTOFF\") | .databaseId")
+
+            if [ -z "$IDS" ]; then
+              echo "No stuck $STATUS runs found"
+            else
+              echo "Cancelling: $IDS"
+              echo "$IDS" | xargs -I{} gh run cancel {} --repo "$REPO"
+            fi
+          done


### PR DESCRIPTION
**Change**
- Add new action which  kills long running, stuck workflows 
- Action will cancel any workflow which run over X minutes
- Merging to main branch for testing before setting "stable" tag 