### PR TITLE
CORE-3147 Implement missing cd for tf_path input in terraform init

### DIFF
--- a/tf-build/init/action.yml
+++ b/tf-build/init/action.yml
@@ -56,6 +56,7 @@ runs:
     - name: Terraform Init
       id: init
       run: |
+        cd ${{ inputs.tf_path }}
         terraform init -backend=${{ env.BACKEND }} -backend-config environments/${{ env.ENVIRONMENT }}/backend.conf -reconfigure --upgrade=${{ inputs.upgrade }}
       shell: bash
 


### PR DESCRIPTION
All the other actions include this command, but it looks like this one got missed.
