### PR TITLE
CORE-3675 make lambda-build action reusable by any lambda

### DIFF
--- a/lambda-build/build/action.yml
+++ b/lambda-build/build/action.yml
@@ -4,7 +4,14 @@ inputs:
   function_name:
     description: The name of the lambda function
     required: true
-
+  files:
+    required: false
+    description: Space-separated list of files to include
+    default: "handler.py"
+  directories:
+    required: false
+    description: Space-separated list of directories to include
+    default: ""
 runs:
   using: "composite"
 
@@ -27,6 +34,8 @@ runs:
       run: ${{ github.action_path }}/build_lambda.sh
       env:
         FUNCTION_NAME: ${{ inputs.function_name }}
+        FILES: ${{ inputs.files }}
+        DIRECTORIES: ${{ inputs.directories }}
 
     - name: Store lambda artifact
       uses: actions/upload-artifact@v7.0.1 # Upgrade version here to update all pipelines using this action

--- a/lambda-build/build/build_lambda.sh
+++ b/lambda-build/build/build_lambda.sh
@@ -18,9 +18,25 @@ uv pip install \
 
 rm requirements.txt
 
-cp config.py ${dist_folder}
-cp handler.py ${dist_folder}
-cp -r modules ${dist_folder}
+# Copy files
+for file in ${FILES}; do
+    if [[ -f "$file" ]]; then
+        cp "$file" "${dist_folder}"
+    else
+        echo "File '$file' not found"
+        exit 1
+    fi
+done
+
+# Copy directories
+for dir in ${DIRECTORIES}; do
+    if [[ -d "$dir" ]]; then
+        cp -R "$dir" "${dist_folder}"
+    else
+        echo "Directory '$dir' not found"
+        exit 1
+    fi
+done
 
 cd ${dist_folder}
 zip -r "${FUNCTION_NAME}.zip" .


### PR DESCRIPTION
The lambda-build action has cp commands which are specific for mono-lambda and this cannot be used for any other lambdas.

Tested with cdp-ecs-webshell-lambda:
<img width="798" height="439" alt="image" src="https://github.com/user-attachments/assets/045f6b79-dd31-4554-a953-2c97abef6ab6" />
