### PR TITLE
CORE-3641 Support building from subfolders

### DIFF
--- a/docker-build/build-image/action.yml
+++ b/docker-build/build-image/action.yml
@@ -4,6 +4,10 @@ inputs:
   image_name:
     description: Name for the container image
     required: true
+  path:
+    description: Path to the Dockerfile and supporting files
+    default: .
+    required: false
   tag:
     description: Tag for the container image
     default: latest
@@ -15,5 +19,5 @@ runs:
     - name: Local build
       run: |
         echo "Building container docker image"
-        docker build --no-cache --tag ${{ inputs.image_name }}:${{ inputs.tag }} .
+        docker build --no-cache --tag ${{ inputs.image_name }}:${{ inputs.tag }} ${{ inputs.path }}
       shell: bash


### PR DESCRIPTION
- Handy when a repo has multiple Dockerfiles separated by directory.
- Preserves default behaviour of building from the Dockerfile in the current working directory.
