### PR TITLE
CORE-3643 Replace dockerised checkov action with uv tool

### DIFF
--- a/tf-build/checkov/README.md
+++ b/tf-build/checkov/README.md
@@ -1,11 +1,12 @@
 # Centralized Checkov Scan Action
 
-This composite action provides a standardized wrapper for the [Bridgecrew Checkov Action](https://github.com/bridgecrewio/checkov-action). It centralizes the versioning and default configuration for Infrastructure as Code (IaC) security scanning across all workflows in this repository.
+This composite action provides a standardized wrapper for a pinned [Checkov](https://www.checkov.io/) CLI invocation. It centralizes the versioning and default configuration for Infrastructure as Code (IaC) security scanning across all workflows in this repository.
 
 ## Why Use This Action?
 
-* **Single Source of Truth:** Manage the Checkov version (`v12`) in one file rather than updating dozens of workflow files.
+* **Single Source of Truth:** Manage the Checkov version (`3.3.9`) in one file rather than updating dozens of workflow files.
 * **Consistent Policy:** Ensures that the Prisma API URL, output formats, and framework settings are identical across the organization.
+* **Runner Compatibility:** Avoids the Docker-action path and problem matcher issues seen on persistent self-hosted runners.
 * **Clean Workflows:** Reduces boilerplate code in your main CI/CD pipeline files.
 
 ## Inputs

--- a/tf-build/checkov/action.yml
+++ b/tf-build/checkov/action.yml
@@ -22,11 +22,24 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v8.1.0
+
     - name: Terraform - checkov
       id: checkov
-      uses: bridgecrewio/checkov-action@v12 # VERSION MANAGED HERE
-      with:
-        quiet: ${{ inputs.quiet }}
-        framework: ${{ inputs.framework }}
-        output_format: ${{ inputs.output_format }}
-        prisma-api-url: ${{ inputs.prisma-api-url }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        args=(
+          --directory .
+          --framework "${{ inputs.framework }}"
+          --output "${{ inputs.output_format }}"
+          --prisma-api-url "${{ inputs.prisma-api-url }}"
+        )
+
+        if [[ "${{ inputs.quiet }}" == 'true' ]]; then
+          args+=(--quiet)
+        fi
+
+        uv tool run --from "checkov==3.3.9" checkov "${args[@]}"


### PR DESCRIPTION
We were encountering several issues with the use of the dockerised action when running checkov on persistent self-hosted runners.

In particular, there seems to be an issue with between how the work directory is mounted between the host, the runner container and the action container and how the checkov container action registers problem matchers:

```
Error: Unable to process command '::add-matcher::checkov-problem-matcher.json' successfully.
Error: Could not find file '/home/runner/actions-runner/_work/cdp-tf-svc-bedrock/cdp-tf-svc-bedrock/checkov-problem-matcher.json'.
```

Troubleshooting attempts were ultimately fruitless. As this appears to be the only issue we're having with the docker-out-of-docker pattern, it felt more pragmatic to workaround the issue with a drop in uv tool replacement instead of implementing a more convoluted workaround.

Tested with an `experimental` tag here > https://github.com/DEFRA/cdp-tf-svc-bedrock/actions/runs/31162728221/job/92817219060.
