### PR TITLE
CORE-3643 Remove GitHub credential persistance and git config changes

### DIFF
--- a/checkout/action.yml
+++ b/checkout/action.yml
@@ -34,3 +34,4 @@ runs:
         ref: ${{ inputs.ref }}
         repository: ${{ inputs.repository || github.repository }}
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false

--- a/tf-build/secrets/action.yml
+++ b/tf-build/secrets/action.yml
@@ -59,7 +59,22 @@ runs:
     # Set Git Config using step output
     - name: git config url rewrite for internal repo access
       run: |
-        git config --local --remove-section http."https://github.com/"
-        git config --global url."https://x-access-token:${{ steps.cdp-gh-action.outputs.token }}@github.com".insteadOf "https://github.com"
-        git config --list
+        GLOBAL_GIT_CONFIG_FILE="${RUNNER_TEMP}/cdp-gitconfig"
+
+        # Ensure all later git commands (including terraform module fetches from temp dirs)
+        # read credentials from a job-scoped global config file.
+        echo "GIT_CONFIG_GLOBAL=${GLOBAL_GIT_CONFIG_FILE}" >> "$GITHUB_ENV"
+        echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
+
+        # Start from a clean per-job config file to avoid stale values.
+        rm -f "${GLOBAL_GIT_CONFIG_FILE}"
+
+        git config --file "${GLOBAL_GIT_CONFIG_FILE}" url."https://x-access-token:${{ steps.cdp-gh-action.outputs.token }}@github.com".insteadOf "https://github.com"
+
+        # If checkout inserted any local GitHub auth header, remove it to avoid precedence issues.
+        git config --local --unset-all http.https://github.com/.extraheader || true
+
+        # Diagnostic output (token redacted).
+        git config --file "${GLOBAL_GIT_CONFIG_FILE}" --get-regexp '^url\..*\.insteadof$' | sed -E 's/x-access-token:[^@]+@/x-access-token:***@/g' || true
+        git config --show-origin --get-all http.https://github.com/.extraheader || true
       shell: bash


### PR DESCRIPTION
Attempt to fix intermittent problems with downloading modules on persistent GitHub runners. Hypothesis is that this is caused by expired credentials, which this attempts to avoid:

```
  Error: Terraform exited with code 1.
  │ Error: Failed to download module
  │
  │   on main.tf line 2:
  │    2: module "tenant_config" {
  │
  │ Could not download module "tenant_config" (main.tf:2) source code from
  │ "git::https://github.com/DEFRA/cdp-tenant-config.git": error downloading
  │ 'https://github.com/DEFRA/cdp-tenant-config.git': /usr/bin/git exited with
  │ 128: Cloning into '.terraform/modules/tenant_config'...
  │ remote: Invalid username or token. Password authentication is not supported
  │ for Git operations.
  │ fatal: Authentication failed for
  │ 'https://github.com/DEFRA/cdp-tenant-config.git/'
```
