### PR TITLE
CORE-3643 Continue on error when looking for state lock

### DIFF
--- a/tf-build/get-tf-state-lock-id/action.yml
+++ b/tf-build/get-tf-state-lock-id/action.yml
@@ -20,12 +20,13 @@ runs:
     - name: Fetch Lock Info from DynamoDB
       id: get-lock-info
       run: |
+        set +e
         aws dynamodb get-item \
           --table-name "${{ inputs.dynamodb_table }}" \
           --key '{"LockID": {"S": "${{ inputs.lock_key }}"}}' \
           --projection-expression "Info" \
           --output json > lock_item.json
-        
+
         lock_id=$(jq -r '.Item.Info.S | fromjson | .ID' lock_item.json)
         if [ -z "$lock_id" ] || [ "$lock_id" = "null" ]; then
           echo "No lock found. Skipping force-unlock."


### PR DESCRIPTION
Currently because GitHub actions shell steps use the `e` option by default, the workflow fails if the state is not actually locked. This is because when the `get-item` command does not find a lock entry in the DynamoDB table the AWS CLI returns a non-zero exit code. This means we never got to the `echo "No lock found. Skipping force-unlock."` and `exit 0` statements.

We now continue on error so the error handling takes effect.
